### PR TITLE
Stop profile being displayed on reload after token expired

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,9 +58,9 @@
               auth.authenticate(store.get('profile'), token);
             }
           } 
-        } 
-        else {          
-          // Otherwise, redirect to the home route
+        }
+
+        if (!auth.isAuthenticated) {
           $location.path('/home');
         }
       });


### PR DESCRIPTION
If the user is on the Profile page when the token expires and they then reload the application the profile page is still displayed even though the toolbar correctly reflects their new authentication status.

This pull request detects that situation and redirects the user to the home page.
